### PR TITLE
Solve serialization problem for Jackson ObjectMapper

### DIFF
--- a/src/main/scala/com/oreilly/learningsparkexamples/scala/BasicParseJsonWithJackson.scala
+++ b/src/main/scala/com/oreilly/learningsparkexamples/scala/BasicParseJsonWithJackson.scala
@@ -27,18 +27,29 @@ object BasicParseJsonWithJackson {
     val outputFile = args(2)
     val sc = new SparkContext(master, "BasicParseJsonWithJackson", System.getenv("SPARK_HOME"))
     val input = sc.textFile(inputFile)
-    val mapper = new ObjectMapper with ScalaObjectMapper
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-    mapper.registerModule(DefaultScalaModule)
-    // Parse it into a specific case class. We use flatMap to handle errors
-    // by returning an empty list (None) if we encounter an issue and a
-    // list with one element if everything is ok (Some(_)).
-    val result = input.flatMap(record => {
-      try {
-        Some(mapper.readValue(record, classOf[Person]))
-      } catch {
-        case e: Exception => None
-      }})
+    
+    // Parse it into a specific case class. We use mapPartitions beacuse:
+    // (a) ObjectMapper is not serializable so we either create a singleton object encapsulating ObjectMapper
+    //     on the driver and have to send data back to the driver to go through the singleton object.
+    //     Alternatively we can let each node create its own ObjectMapper but that's expensive in a map
+    // (b) To solve for creating an ObjectMapper on each node without being too expensive we create one per
+    //     partition with mapPartitions. Solves serialization and object creation performance hit.
+    val result = input.mapPartitions(records => {
+        // mapper object created on each executor node
+        val mapper = new ObjectMapper with ScalaObjectMapper
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        mapper.registerModule(DefaultScalaModule)
+        // We use flatMap to handle errors
+        // by returning an empty list (None) if we encounter an issue and a
+        // list with one element if everything is ok (Some(_)).
+        records.flatMap(record => {
+          try {
+            Some(mapper.readValue(record, classOf[ioRecord]))
+          } catch {
+            case e: Exception => None
+          }
+        })
+      }, true)
     result.filter(_.lovesPandas).map(mapper.writeValueAsString(_))
       .saveAsTextFile(outputFile)
     }


### PR DESCRIPTION
Code as is doesn't work on a distributed system due to serialization of the ObjectMapper. There are 2 solutions for this. Abstract the ObjectMapper within a singleton Object class on the driver. This has performance implications that everything going through that has to be on the driver node. This may or may not be an issue depending on where you're at in processing. If this is the very first step, then perhaps the driver is the best place for this. While good in that case, it still keeps receiving and processing concerns coupled and a repartition of the stream won't help add processing capacity if this is the bottleneck.

The alternative approach, as demonstrated by the code, is to have each execute create the object using mapPartitions to alleviate heavy object creation, i.e., so we don't create the object for each record and instead, once per partition.