### PR TITLE
directly use Configuration instead of getting from job in BasicSaveProtobuf example

### DIFF
--- a/src/main/scala/com/oreilly/learningsparkexamples/scala/BasicSaveProtoBuf.scala
+++ b/src/main/scala/com/oreilly/learningsparkexamples/scala/BasicSaveProtoBuf.scala
@@ -11,15 +11,14 @@ import org.apache.spark.SparkContext._
 import org.apache.hadoop.io.Text
 import com.twitter.elephantbird.mapreduce.io.ProtobufWritable
 import com.twitter.elephantbird.mapreduce.output.LzoProtobufBlockOutputFormat
-import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.conf.Configuration
 
 object BasicSaveProtoBuf {
     def main(args: Array[String]) {
       val master = args(0)
       val outputFile = args(1)
       val sc = new SparkContext(master, "BasicSaveProtoBuf", System.getenv("SPARK_HOME"))
-      val job = new Job()
-      val conf = job.getConfiguration
+      val conf = new Configuration()
       LzoProtobufBlockOutputFormat.setClassConf(classOf[Places.Venue], conf);
       val dnaLounge = Places.Venue.newBuilder()
       dnaLounge.setId(1);


### PR DESCRIPTION
Directly using Job in this way is deprecated

https://github.com/apache/hadoop/blob/c1d50a91f7c05e4aaf4655380c8dcd11703ff158/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java#L116

Moreover, we just don't need to use Job, directly use of Configuration seems to be easier to understand.