### PR TITLE
Fixed maven dependency artifact names and added scala.binary.version …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,17 @@
     </dependency>
     <dependency> <!-- Spark dependency -->
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib</artifactId>
+      <artifactId>spark-mllib_2.10</artifactId>
       <version>1.3.1</version>
     </dependency>
     <dependency> <!-- Cassandra -->
       <groupId>com.datastax.spark</groupId>
-      <artifactId>spark-cassandra-connector</artifactId>
+      <artifactId>spark-cassandra-connector_2.10</artifactId>
       <version>1.0.0-rc5</version>
     </dependency>
     <dependency> <!-- Cassandra -->
       <groupId>com.datastax.spark</groupId>
-      <artifactId>spark-cassandra-connector-java</artifactId>
+      <artifactId>spark-cassandra-connector-java_2.10</artifactId>
       <version>1.0.0-rc5</version>
     </dependency>
     <dependency> <!-- Elastic search connector -->
@@ -104,6 +104,7 @@
   </dependencies>
   <properties>
     <java.version>1.7</java.version>
+    <scala.binary.version>2.10</scala.binary.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
…property.

Some artifacts need to be renamed, and a scala.binary.version property needs to be defined for the Maven project to build successfully. See Issues #8 and #9. 