### PR TITLE
Update StreamingLogInput.scala

### DIFF
--- a/src/main/scala/com/oreilly/learningsparkexamples/scala/StreamingLogInput.scala
+++ b/src/main/scala/com/oreilly/learningsparkexamples/scala/StreamingLogInput.scala
@@ -18,11 +18,11 @@ object StreamingLogInput {
     val lines = ssc.socketTextStream("localhost", 7777)
     val errorLines = processLines(lines)
     // Print out the lines with errors, which causes this DStream to be evaluated
-    errorLines.print()
+    print(errorLines)
     // start our streaming context and wait for it to "finish"
     ssc.start()
     // Wait for 10 seconds then exit. To run forever call without a timeout
-    ssc.awaitTermination(10000)
+    ssc.awaitTerminationOrTimeout(10000)
     ssc.stop()
   }
   def processLines(lines: DStream[String]) = {


### PR DESCRIPTION
when i use  the  errorLines.print()  and ssc.awaitTermination(10000),it does not work.

the methods should be  print(errorLines)  and   ssc.awaitTerminationOrTimeout(10000).

it will work.  i think   maybe it is the reason that the spark version is different .